### PR TITLE
学生マスタ更新と部屋テーブルとの中間テーブルの更新コマンドの作成

### DIFF
--- a/src/liberal-uni-president-bot/app/Console/Commands/InitLiberalCommunityUsers.php
+++ b/src/liberal-uni-president-bot/app/Console/Commands/InitLiberalCommunityUsers.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\ChatWorkApi;
+use App\Models\LiberalCommunityRoom;
+use App\Models\LiberalCommunityRoomUser;
+use App\Models\LiberalCommunityUser;
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+
+class InitLiberalCommunityUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'liberal:initLiberalCommunityUsers';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'リベ大の全ユーザーを取得し新規作成する';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $start = time();
+        $now = Carbon::now();
+
+        $chatwork_api = new ChatWorkApi();
+
+        $user_list = [];
+        foreach (LiberalCommunityRoom::all() as $room) {
+            $room_users = [];
+            $other = json_decode($room['other'], true);
+            if ($other['type'] === 'group') {
+                if ($other['role'] === 'admin') {
+                    $users = $chatwork_api->getRoomMembers($room->room_id);
+                    foreach ($users as $user) {
+                        $user_list[$user['account_id']] = [
+                            'account_id' => $user['account_id'],
+                            'other' => json_encode($user, true),
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+
+                        $room_users[] = [
+                            'account_id' => $user['account_id'],
+                            'room_id' => $room->room_id,
+                            'enter_date' => $now,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+
+                    \DB::table('liberal_community_rooms_users')->insert($room_users);
+                }
+            }
+        }
+
+        // 1000ユーザーずつバルクinsert
+        foreach (\array_chunk($user_list, 1000) as $users) {
+            \DB::table('liberal_community_users')->insert($users);
+        }
+
+        echo 'time: ' . (time() - $start) . "[s]\n";
+    }
+}

--- a/src/liberal-uni-president-bot/app/Console/Commands/UpdateLiberalCommunityUsers.php
+++ b/src/liberal-uni-president-bot/app/Console/Commands/UpdateLiberalCommunityUsers.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\ChatWorkApi;
+use App\Models\LiberalCommunityRoom;
+use App\Models\LiberalCommunityRoomUser;
+use App\Models\LiberalCommunityUser;
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+
+class UpdateLiberalCommunityUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'liberal:updateLiberalCommunityUsers';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'リベ大の全ユーザーを取得し更新する';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $start = time();
+        $now = Carbon::now();
+
+        $chatwork_api = new ChatWorkApi();
+
+        $database_all_user_ids = Arr::pluck(LiberalCommunityUser::get(['account_id'])->toArray(), 'account_id');
+        $chatwork_all_user_ids = [];
+        foreach (LiberalCommunityRoom::all() as $room) {
+            $other = json_decode($room['other'], true);
+            if ($other['type'] === 'group') {
+                if ($other['role'] === 'admin') {
+                    $chatwork_room_users = $chatwork_api->getRoomMembers($room->room_id);
+                    $database_room_user_ids = Arr::pluck(LiberalCommunityRoomUser::where('room_id', $room->room_id)->get(['account_id'])->toArray(), 'account_id');
+                    $chatwork_room_user_ids = [];
+                    foreach ($chatwork_room_users as $chatwork_room_user) {
+                        // データベースにいないユーザーは新規登録。今回すでに登録したユーザーはスルー。
+                        if (!\in_array($chatwork_room_user['account_id'], $database_all_user_ids) && !\in_array($chatwork_room_user['account_id'], $chatwork_all_user_ids)) {
+                            echo 'user: ' . $chatwork_room_user['account_id'] . " 新規登録\n";
+                            LiberalCommunityUser::create([
+                                'account_id' => $chatwork_room_user['account_id'],
+                                'other' => json_encode($chatwork_room_user, true),
+                            ]);
+                        }
+
+                        // データベース上で部屋に所属していないユーザーは新規登録
+                        if (!\in_array($chatwork_room_user['account_id'], $database_room_user_ids)) {
+                            echo 'room: ' . $room->room_id . ', user: ' . $chatwork_room_user['account_id'] . " 入室\n";
+                            LiberalCommunityRoomUser::create([
+                                'account_id' => $chatwork_room_user['account_id'],
+                                'room_id' => $room->room_id,
+                                'enter_date' => Carbon::now(),
+                            ]);
+                        }
+
+                        $chatwork_room_user_ids[] = $chatwork_room_user['account_id'];
+                        $chatwork_all_user_ids[] = $chatwork_room_user['account_id'];
+                    }
+
+                    // 重複を取り除く。
+                    $chatwork_all_user_ids = array_unique($chatwork_all_user_ids);
+
+                    // データベース上で部屋に所属していたが、chatwork上では所属していないユーザーは退出とする。
+                    // 1日の間に退出にするユーザーはそれほど多くないと想像してバルク処理ではなく１件ずつ処理する。
+                    $room_users = LiberalCommunityRoomUser::where('room_id', $room->room_id)->whereNotIn('account_id', $chatwork_room_user_ids)->get();
+                    foreach ($room_users as $user) {
+                        echo 'room: ' . $room->room_id . ', user: ' . $user->account_id . " 退室\n";
+                        $user->leave_date = Carbon::now();
+                        $user->save();
+                    }
+                }
+            }
+        }
+
+        // 1日の間に卒業するユーザーはそれほど多くないと想像してバルク処理ではなく１件ずつ処理する。
+        $delete_users = LiberalCommunityUser::whereNotIn('account_id', $chatwork_all_user_ids)->get();
+        foreach ($delete_users as $user) {
+            echo $user->account_id . ": 削除\n";
+            $user->delete();
+        }
+
+        echo 'time: ' . (time() - $start) . "[s]\n";
+    }
+}

--- a/src/liberal-uni-president-bot/app/Console/Kernel.php
+++ b/src/liberal-uni-president-bot/app/Console/Kernel.php
@@ -13,7 +13,9 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        Commands\LiberalCommunityRooms::class,
+        Commands\InitLiberalCommunityUsers::class,
+        Commands\UpdateLiberalCommunityUsers::class,
     ];
 
     /**

--- a/src/liberal-uni-president-bot/app/Console/Kernel.php
+++ b/src/liberal-uni-president-bot/app/Console/Kernel.php
@@ -28,7 +28,8 @@ class Kernel extends ConsoleKernel
     {
         //自己紹介未完了 または プロフィール写真未設定 は BOTがリプライ
         $schedule->command('liberal:bot')->everyMinute();
-        $schedule->command('liberal:updateLiberalCommunityRooms')->everyMinute();
+        $schedule->command('liberal:updateLiberalCommunityRooms')->dailyAt('03:00');
+        $schedule->command('liberal:updateLiberalCommunityUsers')->dailyAt('04:00');
     }
 
     /**

--- a/src/liberal-uni-president-bot/app/Models/CompositePrimaryKeyTrait.php
+++ b/src/liberal-uni-president-bot/app/Models/CompositePrimaryKeyTrait.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Models;
+
+use \Illuminate\Database\Eloquent\Builder;
+
+
+trait CompositePrimaryKeyTrait
+{
+    /**
+     * 複合キーに対応させるために使用する。
+     * Set the keys for a save update query.
+     *
+     * @param  Builder  $query
+     * @return Builder
+     */
+    protected function setKeysForSaveQuery(Builder $query)
+    {
+        if (is_array($this->primaryKey)) {
+            foreach ($this->primaryKey as $pk) {
+                $query->where($pk, '=', $this->original[$pk]);
+            }
+            return $query;
+        }else{
+            return parent::setKeysForSaveQuery($query);
+        }
+    }
+}

--- a/src/liberal-uni-president-bot/app/Models/LiberalCommunityRoom.php
+++ b/src/liberal-uni-president-bot/app/Models/LiberalCommunityRoom.php
@@ -8,4 +8,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class LiberalCommunityRoom extends Model
 {
     use SoftDeletes;
+
+    protected $primaryKey = 'room_id';
+
+    public $incrementing  = false;
 }

--- a/src/liberal-uni-president-bot/app/Models/LiberalCommunityRoomUser.php
+++ b/src/liberal-uni-president-bot/app/Models/LiberalCommunityRoomUser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class LiberalCommunityRoomUser extends Model
+{
+    use CompositePrimaryKeyTrait;
+
+    protected $table = 'liberal_community_rooms_users';
+
+    protected $primaryKey = ['account_id', 'room_id'];
+
+    public $incrementing  = false;
+
+    protected $fillable = [
+        'account_id', 'room_id', 'enter_date', 'leave_date',
+    ];
+}

--- a/src/liberal-uni-president-bot/app/Models/LiberalCommunityUser.php
+++ b/src/liberal-uni-president-bot/app/Models/LiberalCommunityUser.php
@@ -3,7 +3,17 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class LiberalCommunityUser extends Model
 {
+    use SoftDeletes;
+
+    protected $primaryKey = 'account_id';
+
+    public $incrementing  = false;
+
+    protected $fillable = [
+        'account_id', 'other',
+    ];
 }

--- a/src/liberal-uni-president-bot/composer.json
+++ b/src/liberal-uni-president-bot/composer.json
@@ -13,6 +13,7 @@
         "guzzlehttp/guzzle": "^6.4",
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",
+        "nesbot/carbon": "^2.27",
         "predis/predis": "^1.1"
     },
     "require-dev": {

--- a/src/liberal-uni-president-bot/composer.lock
+++ b/src/liberal-uni-president-bot/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc7a484cdbd6358569ed9b0a14f91893",
+    "content-hash": "43be1f12b9b3b004d2c4e0bd27408aba",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1032,22 +1032,22 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.25.1",
+            "version": "2.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "d59c6cea9c4a3547bb6c0dfec451319abdaa4fb1"
+                "reference": "13b8485a8690f103bf19cba64879c218b102b726"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/d59c6cea9c4a3547bb6c0dfec451319abdaa4fb1",
-                "reference": "d59c6cea9c4a3547bb6c0dfec451319abdaa4fb1",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/13b8485a8690f103bf19cba64879c218b102b726",
+                "reference": "13b8485a8690f103bf19cba64879c218b102b726",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
-                "symfony/translation": "^3.4 || ^4.0"
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
@@ -1062,6 +1062,9 @@
             ],
             "type": "library",
             "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                },
                 "laravel": {
                     "providers": [
                         "Carbon\\Laravel\\ServiceProvider"
@@ -1095,7 +1098,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2019-10-05T15:52:23+00:00"
+            "time": "2019-11-20T06:59:06+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/src/liberal-uni-president-bot/database/migrations/2019_12_03_120000_modify_liberal_community_rooms_primarykey_table.php
+++ b/src/liberal-uni-president-bot/database/migrations/2019_12_03_120000_modify_liberal_community_rooms_primarykey_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyLiberalCommunityRoomsPrimarykeyTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('liberal_community_rooms', function (Blueprint $table): void {
+            $table->dropColumn('id');
+            $table->dropUnique('liberal_community_rooms_room_id_unique');
+        });
+        Schema::table('liberal_community_rooms', function (Blueprint $table): void {
+            $table->primary('room_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('liberal_community_rooms', function (Blueprint $table): void {
+            $table->dropPrimary('PRIMARY');
+        });
+        Schema::table('liberal_community_rooms', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unique('room_id');
+        });
+    }
+}

--- a/src/liberal-uni-president-bot/database/migrations/2019_12_03_120001_modify_liberal_community_users_primarykey_table.php
+++ b/src/liberal-uni-president-bot/database/migrations/2019_12_03_120001_modify_liberal_community_users_primarykey_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyLiberalCommunityUsersPrimarykeyTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('liberal_community_users', function (Blueprint $table): void {
+            $table->dropColumn('id');
+            $table->dropUnique('liberal_community_users_account_id_unique');
+        });
+        Schema::table('liberal_community_users', function (Blueprint $table): void {
+            $table->primary('account_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('liberal_community_users', function (Blueprint $table): void {
+            $table->dropPrimary('PRIMARY');
+        });
+        Schema::table('liberal_community_users', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unique('account_id');
+        });
+    }
+}

--- a/src/liberal-uni-president-bot/database/migrations/2019_12_03_130000_create_liberal_community_rooms_users_table.php
+++ b/src/liberal-uni-president-bot/database/migrations/2019_12_03_130000_create_liberal_community_rooms_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLiberalCommunityRoomsUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('liberal_community_rooms_users', function (Blueprint $table) {
+            $table->unsignedBigInteger('room_id')->comment('chatworkから取得できるルームID');
+            $table->unsignedBigInteger('account_id')->comment('chatworkから取得できるアカウントID');
+            $table->date('enter_date')->comment('ユーザーが部屋に入室した日');
+            $table->date('leave_date')->nullable()->comment('ユーザーが部屋から退室した日');
+            $table->timestamps();
+
+            $table->primary(['room_id', 'account_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('liberal_community_rooms_users');
+    }
+}


### PR DESCRIPTION
・中間テーブルのmigrationファイルを作成
・roomsテーブルとusersテーブルのprimaryKeyを変更するmigrationファイルを作成
・ユーザー一覧・中間テーブルの初期投入コマンドの実装
・ユーザー一覧・中間テーブルの更新用コマンドの実装

php artisan liberal:updateLiberalCommunityRooms // ルームマスタの更新
php artisan liberal:initLiberalCommunityUsers // ユーザー一覧初期投入
php artisan liberal:updateLiberalCommunityUsers // ユーザー一覧更新